### PR TITLE
SAF-67: Static: Route sidebar buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,12 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import './App.css';
+import { Gases } from "./components/Gases";
 import { Home } from "./components/Home";
+import { Incidents } from "./components/Incidents";
+import { Locations } from "./components/Locations";
 import { Sidebar } from "./components/Sidebar";
+import { UserAccount } from "./components/UserAccount";
 
 const theme = createTheme({
   typography: {
@@ -21,6 +25,10 @@ function App() {
           {/* no component for login yet*/}
           <Route exact path="/login" />
           <Route exact path="/" component={Home}></Route>
+          <Route exact path="/locations" component={Locations}></Route>
+          <Route exact path="/incidents" component={Incidents}></Route>
+          <Route exact path="/gases" component={Gases}></Route>
+          <Route exact path="/user-account" component={UserAccount}></Route>
         </Switch>
       </Router>
     </ThemeProvider>

--- a/src/components/Gases.tsx
+++ b/src/components/Gases.tsx
@@ -1,0 +1,18 @@
+import { makeStyles } from "@mui/styles";
+import React from "react";
+
+const useStyles = makeStyles({
+  placeholderDiv: {
+    textAlign: "center",
+  },
+});
+
+export const Gases: React.FC = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.placeholderDiv}>
+      <h1>Gases</h1>
+    </div>
+  );
+};

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import SaveIcon from "@mui/icons-material/Save";
 import UndoIcon from "@mui/icons-material/Undo";
-import Button from "@mui/material/Button";
 import SpeedDial from "@mui/material/SpeedDial";
 import SpeedDialAction from "@mui/material/SpeedDialAction";
 import SpeedDialIcon from "@mui/material/SpeedDialIcon";
@@ -10,10 +9,8 @@ import React from "react";
 
 /* see https://mui.com/styles/basics/ */
 const useStyles = makeStyles({
-  homeButton: {
-    boxShadow: "0 3px 5px 2px rgba(255, 105, 135, .3)",
-    color: "red",
-    height: 69,
+  placeholderDiv: {
+    textAlign: "center",
   },
   fab: {
     backgroundColor: "#d34949",
@@ -28,7 +25,7 @@ const actions = [
 ];
 
 export const Home: React.FC = () => {
-  const classes = useStyles();
+  const styles = useStyles();
 
   return (
     <div>
@@ -46,11 +43,9 @@ export const Home: React.FC = () => {
           />
         ))}
       </SpeedDial>
-      <h1>Home</h1>
-      {/* you can add custom styling to MUI components using useStyles! yay! */}
-      <Button className={classes.homeButton} variant="contained">
-        wassup
-      </Button>
+      <div className={styles.placeholderDiv}>
+        <h1>Home</h1>
+      </div>
     </div>
   );
 };

--- a/src/components/Incidents.tsx
+++ b/src/components/Incidents.tsx
@@ -1,0 +1,18 @@
+import { makeStyles } from "@mui/styles";
+import React from "react";
+
+const useStyles = makeStyles({
+  placeholderDiv: {
+    textAlign: "center",
+  },
+});
+
+export const Incidents: React.FC = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.placeholderDiv}>
+      <h1>Incidents</h1>
+    </div>
+  );
+};

--- a/src/components/Locations.tsx
+++ b/src/components/Locations.tsx
@@ -1,0 +1,18 @@
+import { makeStyles } from "@mui/styles";
+import React from "react";
+
+const useStyles = makeStyles({
+  placeholderDiv: {
+    textAlign: "center",
+  },
+});
+
+export const Locations: React.FC = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.placeholderDiv}>
+      <h1>Locations</h1>
+    </div>
+  );
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,13 +7,14 @@ import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
 import Drawer from "@mui/material/Drawer";
 import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import { StyledEngineProvider } from "@mui/material/styles";
 import Toolbar from "@mui/material/Toolbar";
 import { makeStyles } from "@mui/styles";
 import React from "react";
+import { Link as RouterLink } from "react-router-dom";
 
 const useStyles = makeStyles({
   sidebar: {
@@ -48,10 +49,10 @@ export const Sidebar: React.FC = () => {
   const styles = useStyles();
 
   const sidebarItems = [
-    { text: "Dashboard", icon: HomeOutlinedIcon },
-    { text: "Locations", icon: ExploreOutlinedIcon },
-    { text: "Incidents", icon: BarChartOutlinedIcon },
-    { text: "Gases", icon: BubbleChartOutlinedIcon },
+    { text: "Home", icon: HomeOutlinedIcon, link: "/" },
+    { text: "Locations", icon: ExploreOutlinedIcon, link: "/locations" },
+    { text: "Incidents", icon: BarChartOutlinedIcon, link: "/incidents" },
+    { text: "Gases", icon: BubbleChartOutlinedIcon, link: "/gases" },
   ];
   return (
     <StyledEngineProvider injectFirst>
@@ -62,22 +63,26 @@ export const Sidebar: React.FC = () => {
           <Box className={styles.sidebarMenu}>
             <List>
               {sidebarItems.map((sidebarItem) => (
-                <ListItem button key={sidebarItem.text}>
+                <ListItemButton
+                  component={RouterLink}
+                  key={sidebarItem.text}
+                  to={sidebarItem.link}
+                >
                   <ListItemIcon>
                     <sidebarItem.icon />
                   </ListItemIcon>
                   <ListItemText primary={sidebarItem.text} />
-                </ListItem>
+                </ListItemButton>
               ))}
             </List>
           </Box>
           <List className={styles.sidebarFooter}>
-            <ListItem button>
+            <ListItemButton component={RouterLink} to="/user-account">
               <ListItemIcon>
                 <AccountCircleOutlinedIcon />
               </ListItemIcon>
               <ListItemText primary="User Account" />
-            </ListItem>
+            </ListItemButton>
           </List>
         </Drawer>
       </Box>

--- a/src/components/UserAccount.tsx
+++ b/src/components/UserAccount.tsx
@@ -1,0 +1,18 @@
+import { makeStyles } from "@mui/styles";
+import React from "react";
+
+const useStyles = makeStyles({
+  placeholderDiv: {
+    textAlign: "center",
+  },
+});
+
+export const UserAccount: React.FC = () => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.placeholderDiv}>
+      <h1>User Account</h1>
+    </div>
+  );
+};


### PR DESCRIPTION
Routed the sidebar buttons to their corresponding pages. As a result,
the pages were created but only contain placeholder elements (i.e., the
title of the page).

Additionally, simplified the Home page to match with the other pages.
That is, the dummy button was removed and the title was horizontally
centered.