### PR TITLE
SAF-103: Static: Match red with company logo's red

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
     textAlign: "center",
   },
   fab: {
-    backgroundColor: "#d34949",
+    backgroundColor: "#ad172b",
   },
 });
 
@@ -33,7 +33,7 @@ export const Home: React.FC = () => {
         ariaLabel="SpeedDial"
         sx={{ position: "absolute", bottom: 16, right: 16 }}
         icon={<SpeedDialIcon />}
-        FabProps={{ style: { backgroundColor: "#d34949" } }}
+        FabProps={{ style: { backgroundColor: "#ad172b" } }}
       >
         {actions.map((action) => (
           <SpeedDialAction

--- a/src/components/UI/atoms/Sidebar.tsx
+++ b/src/components/UI/atoms/Sidebar.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 
     "& .MuiPaper-root": {
-      backgroundColor: "#d34949",
+      backgroundColor: "#ad172b",
       boxSizing: "border-box",
       color: "white",
       width: 240,
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 
     "& .MuiPaper-root": {
-      backgroundColor: "#d34949",
+      backgroundColor: "#ad172b",
       boxSizing: "border-box",
       color: "white",
       width: 240,
@@ -85,9 +85,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 
   sidebarItemSelected: {
-    backgroundColor: "#ad172b",
+    backgroundColor: "#d34949",
 
-    "&:hover": { backgroundColor: "#ad172b80" },
+    "&:hover": { backgroundColor: "#d3494980" },
   },
 
   sidebarFooter: {


### PR DESCRIPTION
Our web application uses two shades of red. Make the primary color match
the red used in Blackline Safety's logo. The secondary color is the
lighter shade of red. In other words, switch the two shades of red.