### PR TITLE
SAF-322: Add Google API key (public)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
     -->
     <title>Blackline Safety</title>
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
-    <script src="//maps.googleapis.com/maps/api/js?key=&libraries=visualization"></script>
+    <script src="//maps.googleapis.com/maps/api/js?key=AIzaSyApFckCQhcYUvARQ93jU7Qhk9Uyuxbk7xA&libraries=visualization"></script>
   </head>
   <body>
     <!--    <noscript>You need to enable JavaScript to run this app.</noscript>-->


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-322

This pull request adds a Google Maps API key. The key will make maps appear genuine instead of showing a "for development purposes only" message. The key is restricted and can therefore safety be committed to GitHub where it is publicly visible.