### PR TITLE
SAF-336: Disable filtering past today

### DIFF
--- a/src/components/UI/molecules/FilterBar.tsx
+++ b/src/components/UI/molecules/FilterBar.tsx
@@ -117,6 +117,7 @@ export const FilterBar: React.FC<FilterBarProps> = (props) => {
                 renderInput={(props) => <TextField {...props} />}
                 value={props.filter.minTimestamp || null}
                 onChange={minTimestampChanged}
+                maxDateTime={tomorrow()}
               />
             </FormControl>
           </div>
@@ -131,6 +132,7 @@ export const FilterBar: React.FC<FilterBarProps> = (props) => {
                 renderInput={(props) => <TextField {...props} />}
                 value={props.filter.maxTimestamp || null}
                 onChange={maxTimestampChanged}
+                maxDateTime={tomorrow()}
               />
             </FormControl>
           </div>
@@ -176,7 +178,9 @@ export const defaultFilter = (): Filter => ({
 
 export const defaultMinTimestamp = (): Date => new Date(2022, 2, 6);
 
-export const defaultMaxTimestamp = (): Date => {
+export const defaultMaxTimestamp = (): Date => tomorrow();
+
+const tomorrow = (): Date => {
   // Beginning of tomorrow in local time.
   const today = new Date();
   const tomorrow = new Date(today);


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-336

This pull request disables setting start date and end date on the filter past the beginning of tomorrow in local time.