### PR TITLE
SAF-339: Make datetime pickers clearable on mobile

### DIFF
--- a/src/components/UI/molecules/FilterBar.tsx
+++ b/src/components/UI/molecules/FilterBar.tsx
@@ -141,6 +141,7 @@ export const FilterBar: React.FC<FilterBarProps> = (props) => {
                 value={props.filter.minTimestamp || null}
                 onChange={minTimestampChanged}
                 maxDateTime={maxDateTime}
+                clearable={true}
               />
             </FormControl>
           </div>
@@ -157,6 +158,7 @@ export const FilterBar: React.FC<FilterBarProps> = (props) => {
                 value={props.filter.maxTimestamp || null}
                 onChange={maxTimestampChanged}
                 maxDateTime={maxDateTime}
+                clearable={true}
               />
             </FormControl>
           </div>


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-339

This pull request makes the filter modal datetime picker clearable on mobile.

![image](https://user-images.githubusercontent.com/20851553/159193388-7f3a1b02-79f6-4102-833a-b0ed44569d92.png)
