### PR TITLE
SAF-349: Disable map greedy gesture handling on mobile

### DIFF
--- a/src/components/UI/molecules/HazardMap.tsx
+++ b/src/components/UI/molecules/HazardMap.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect } from "react";
-import { getCurrentUser, MAP_RESTRICTION, User } from "../../../index";
+import {
+  getCurrentUser,
+  MAP_RESTRICTION,
+  useMapGestureHandling,
+  User,
+} from "../../../index";
 import { GoogleMap, HeatmapLayer } from "@react-google-maps/api";
 import { Filter, shouldFilterPerson } from "./FilterBar";
 import {
@@ -13,8 +18,6 @@ import EmptyDataMessage from "../atoms/EmptyDataMessage";
 import Backdrop from "@mui/material/Backdrop";
 import OverlayStyles from "../../styling/OverlayStyles";
 import LatLngLiteral = google.maps.LatLngLiteral;
-import { useMediaQuery } from "@mui/material";
-import theme from "../../../Theme";
 
 export const DEFAULT_MAP_CENTER: LatLngLiteral = {
   lat: 51.045,
@@ -35,10 +38,6 @@ export const HazardMap: React.FC<HazardMapProps> = (props) => {
 
   const incidents: Incident[] = useIncidents(user, filter);
   const points: WeightedLocation[] = intoPoints(incidents);
-
-  const gestureHandling = useMediaQuery(theme.breakpoints.down("md"))
-    ? "cooperative"
-    : "greedy";
 
   useEffect(() => {
     if (incidents.length === 0) {
@@ -63,7 +62,7 @@ export const HazardMap: React.FC<HazardMapProps> = (props) => {
           width: "100%",
         }}
         options={{
-          gestureHandling: gestureHandling,
+          gestureHandling: useMapGestureHandling(),
           restriction: MAP_RESTRICTION,
         }}
         zoom={DEFAULT_MAP_ZOOM}

--- a/src/components/UI/molecules/IncidentsMap.tsx
+++ b/src/components/UI/molecules/IncidentsMap.tsx
@@ -3,6 +3,7 @@ import {
   getCurrentUser,
   MAP_RESTRICTION,
   sortPeople,
+  useMapGestureHandling,
   User,
 } from "../../../index";
 import { GoogleMap, Marker } from "@react-google-maps/api";
@@ -83,7 +84,7 @@ export const IncidentsMap: React.FC<IncidentsMapProps> = (props) => {
           width: "100%",
         }}
         options={{
-          gestureHandling: "greedy",
+          gestureHandling: useMapGestureHandling(),
           restriction: MAP_RESTRICTION,
         }}
         zoom={DEFAULT_MAP_ZOOM}

--- a/src/components/UI/molecules/TravelMap.tsx
+++ b/src/components/UI/molecules/TravelMap.tsx
@@ -10,6 +10,7 @@ import {
   MAP_RESTRICTION,
   modularIndex,
   sortPeople,
+  useMapGestureHandling,
   User,
 } from "../../../index";
 import { GoogleMap, Polyline } from "@react-google-maps/api";
@@ -178,7 +179,7 @@ export const TravelMap: React.FC<TravelMapProps> = (props) => {
             width: "100%",
           }}
           options={{
-            gestureHandling: "greedy",
+            gestureHandling: useMapGestureHandling(),
             restriction: MAP_RESTRICTION,
           }}
           zoom={DEFAULT_MAP_ZOOM}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,8 @@ import reportWebVitals from "./reportWebVitals";
 import { store } from "./store/store";
 import { Person } from "./util/queryService";
 import MapRestriction = google.maps.MapRestriction;
+import { useMediaQuery } from "@mui/material";
+import theme from "./Theme";
 
 export const API_URL = "https://func-api-nmisvbwuqreyq.azurewebsites.net";
 export const MAP_RESTRICTION: MapRestriction = {
@@ -48,6 +50,9 @@ export const sortPeople = <T extends Person>(people: T[]): T[] =>
 
 export const modularIndex = <T,>(arr: T[], index: number): T =>
   arr[index % arr.length];
+
+export const useMapGestureHandling = () =>
+  useMediaQuery(theme.breakpoints.down("md")) ? "cooperative" : "greedy";
 
 const client = new ApolloClient({
   uri: `${API_URL}/graphql`,


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-349

This pull request makes it such that:
- Maps have greedy gesture handling on large screens and cooperative gesture handling on small screen. Desktop users will not need to hold control to zoom in (greedy).  Mobile users must use two fingers to zoom (cooperative) so they can scroll the page with one finger.