### PR TITLE
SAF-359: Maps always use greedy gesture handling

### DIFF
--- a/src/components/UI/molecules/HazardMap.tsx
+++ b/src/components/UI/molecules/HazardMap.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect } from "react";
-import {
-  getCurrentUser,
-  MAP_RESTRICTION,
-  useMapGestureHandling,
-  User,
-} from "../../../index";
+import { getCurrentUser, MAP_RESTRICTION, User } from "../../../index";
 import { GoogleMap, HeatmapLayer } from "@react-google-maps/api";
 import { Filter, shouldFilterPerson } from "./FilterBar";
 import {
@@ -62,7 +57,7 @@ export const HazardMap: React.FC<HazardMapProps> = (props) => {
           width: "100%",
         }}
         options={{
-          gestureHandling: useMapGestureHandling(),
+          gestureHandling: "greedy",
           restriction: MAP_RESTRICTION,
         }}
         zoom={DEFAULT_MAP_ZOOM}

--- a/src/components/UI/molecules/IncidentsMap.tsx
+++ b/src/components/UI/molecules/IncidentsMap.tsx
@@ -3,7 +3,6 @@ import {
   getCurrentUser,
   MAP_RESTRICTION,
   sortPeople,
-  useMapGestureHandling,
   User,
 } from "../../../index";
 import { GoogleMap, Marker } from "@react-google-maps/api";
@@ -84,7 +83,7 @@ export const IncidentsMap: React.FC<IncidentsMapProps> = (props) => {
           width: "100%",
         }}
         options={{
-          gestureHandling: useMapGestureHandling(),
+          gestureHandling: "greedy",
           restriction: MAP_RESTRICTION,
         }}
         zoom={DEFAULT_MAP_ZOOM}

--- a/src/components/UI/molecules/TravelMap.tsx
+++ b/src/components/UI/molecules/TravelMap.tsx
@@ -10,7 +10,6 @@ import {
   MAP_RESTRICTION,
   modularIndex,
   sortPeople,
-  useMapGestureHandling,
   User,
 } from "../../../index";
 import { GoogleMap, Polyline } from "@react-google-maps/api";
@@ -179,7 +178,7 @@ export const TravelMap: React.FC<TravelMapProps> = (props) => {
             width: "100%",
           }}
           options={{
-            gestureHandling: useMapGestureHandling(),
+            gestureHandling: "greedy",
             restriction: MAP_RESTRICTION,
           }}
           zoom={DEFAULT_MAP_ZOOM}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,6 @@ import reportWebVitals from "./reportWebVitals";
 import { store } from "./store/store";
 import { Person } from "./util/queryService";
 import MapRestriction = google.maps.MapRestriction;
-import { useMediaQuery } from "@mui/material";
-import theme from "./Theme";
 import { setContext } from "@apollo/client/link/context";
 
 export const API_URL = "https://func-api-nmisvbwuqreyq.azurewebsites.net";
@@ -63,9 +61,6 @@ export const sortPeople = <T extends Person>(people: T[]): T[] =>
 
 export const modularIndex = <T,>(arr: T[], index: number): T =>
   arr[index % arr.length];
-
-export const useMapGestureHandling = () =>
-  useMediaQuery(theme.breakpoints.down("md")) ? "cooperative" : "greedy";
 
 const httpLink = createHttpLink({
   uri: `${API_URL}/graphql`,


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-359

This pull request makes it such that:
- Google Maps always uses greedy gesture handling.

Previously, Google Maps was configured to use greedy gesture handling on large screens and cooperative gesture handling on small screens. This was so users could scroll the page on mobile. Since tabs are now used on mobile, cooperative gesture handling does not make sense.