### PR TITLE
SAF-401: Show incidents and gas readings tooltips in local time

### DIFF
--- a/src/components/UI/atoms/GasesMap.tsx
+++ b/src/components/UI/atoms/GasesMap.tsx
@@ -128,17 +128,14 @@ export const GasesMap: React.FC<GasDotMapProps> = (props) => {
               location={hoveredMarker.location}
               hoverDistance={"20px"}
             >
-              <h3 className={styles.tooltipText}>Gas: {hoveredMarker.gas}</h3>
+              <h3 className={styles.tooltipText}>{hoveredMarker.gas}</h3>
               <p className={styles.tooltipText}>
-                Name: {hoveredMarker.person.name}
+                {hoveredMarker.density} {hoveredMarker.densityUnits}
               </p>
               <p className={styles.tooltipText}>
-                Time: {hoveredMarker.time.toLocaleString()}
+                {hoveredMarker.time.toLocaleString()}
               </p>
-              <p className={styles.tooltipText}>
-                Density: {hoveredMarker.density}
-                {hoveredMarker.densityUnits}
-              </p>
+              <p className={styles.tooltipText}>{hoveredMarker.person.name}</p>
             </MapTooltip>
           )}
         </GoogleMap>

--- a/src/components/UI/atoms/GasesMap.tsx
+++ b/src/components/UI/atoms/GasesMap.tsx
@@ -133,7 +133,7 @@ export const GasesMap: React.FC<GasDotMapProps> = (props) => {
                 Name: {hoveredMarker.person.name}
               </p>
               <p className={styles.tooltipText}>
-                Time: {hoveredMarker.time.toISOString()}
+                Time: {hoveredMarker.time.toLocaleString()}
               </p>
               <p className={styles.tooltipText}>
                 Density: {hoveredMarker.density}

--- a/src/components/UI/molecules/IncidentsMap.tsx
+++ b/src/components/UI/molecules/IncidentsMap.tsx
@@ -138,14 +138,10 @@ export const IncidentsMap: React.FC<IncidentsMapProps> = (props) => {
               location={hoveredMarker.location}
               hoverDistance={"20px"}
             >
-              <h3 className={styles.tooltipText}>
-                Incident: {hoveredMarker.type}
-              </h3>
+              <h3 className={styles.tooltipText}>{hoveredMarker.type}</h3>
+              <p className={styles.tooltipText}>{hoveredMarker.person.name}</p>
               <p className={styles.tooltipText}>
-                Name: {hoveredMarker.person.name}
-              </p>
-              <p className={styles.tooltipText}>
-                Time: {hoveredMarker.time.toLocaleString()}
+                {hoveredMarker.time.toLocaleString()}
               </p>
             </MapTooltip>
           )}

--- a/src/components/UI/molecules/IncidentsMap.tsx
+++ b/src/components/UI/molecules/IncidentsMap.tsx
@@ -145,7 +145,7 @@ export const IncidentsMap: React.FC<IncidentsMapProps> = (props) => {
                 Name: {hoveredMarker.person.name}
               </p>
               <p className={styles.tooltipText}>
-                Time: {hoveredMarker.time.toISOString()}
+                Time: {hoveredMarker.time.toLocaleString()}
               </p>
             </MapTooltip>
           )}


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-401

This pull request:

- Makes all tooltip times shown in local time.
- Removes labels from the tooltip contents.

Location tooltips were already in local time without labels.

![image](https://user-images.githubusercontent.com/20851553/160393693-60ebf2f4-9c60-4ade-8545-301fdc3a33fe.png)
![image](https://user-images.githubusercontent.com/20851553/160393452-34a0e580-07d4-42a1-9e94-ce5bd2342cbc.png)
![image](https://user-images.githubusercontent.com/20851553/160393900-ea27768c-5280-4baf-a582-d9b66396c161.png)

