### PR TITLE
SAF-430: Partial fix incident tooltip on mobile

### DIFF
--- a/src/components/UI/atoms/GasesMap.tsx
+++ b/src/components/UI/atoms/GasesMap.tsx
@@ -106,6 +106,7 @@ export const GasesMap: React.FC<GasDotMapProps> = (props) => {
               icon={marker.icon}
               onMouseOver={() => onMarkerMouseOver(marker)}
               onMouseOut={() => onMarkerMouseOut(marker)}
+              onClick={() => onMarkerMouseOver(marker)}
             />
           ))}
           {hoveredMarker && (

--- a/src/components/UI/molecules/IncidentsMap.tsx
+++ b/src/components/UI/molecules/IncidentsMap.tsx
@@ -116,6 +116,7 @@ export const IncidentsMap: React.FC<IncidentsMapProps> = (props) => {
               icon={marker.icon}
               onMouseOver={() => onMarkerMouseOver(marker)}
               onMouseOut={() => onMarkerMouseOut(marker)}
+              onClick={() => onMarkerMouseOver(marker)}
             />
           ))}
           {hoveredMarker && (


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-430

Previously, clicking an incident on the incidents map did not show a tooltip on mobile. Strangely, it works correctly on the gases map. This pull request implements a partial fix so the tooltip appears on click. However, clicking away from the incident does not make the tooltip disappear.