### PR TITLE
SAF-436: Add elevation to dashboard header on mobile

### DIFF
--- a/src/components/UI/molecules/DashboardInfo.tsx
+++ b/src/components/UI/molecules/DashboardInfo.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import theme from "../../../Theme";
 import { HomeGreeting } from "../atoms/HomeGreeting";
 import { PageHeader } from "../atoms/PageHeader";
+import Paper from "@mui/material/Paper";
+import { Box } from "@mui/system";
 
 interface DashboardInfoProps {
   activeWidgetState?: any;
@@ -27,7 +29,7 @@ export const DashboardInfo: React.FC<DashboardInfoProps> = (props) => {
   const mobile = useMediaQuery(theme.breakpoints.down("sm"));
   const styles = useStyles();
 
-  return (
+  const content = (
     <div className={styles.content}>
       {!mobile && (
         <PageHeader
@@ -37,6 +39,7 @@ export const DashboardInfo: React.FC<DashboardInfoProps> = (props) => {
           }
         />
       )}
+
       <HomeGreeting
         activeWidgetState={props.activeWidgetState}
         inactiveWidgetState={props.inactiveWidgetState}
@@ -46,5 +49,21 @@ export const DashboardInfo: React.FC<DashboardInfoProps> = (props) => {
         setEditDashboardMode={props.setEditDashboardMode}
       />
     </div>
+  );
+
+  return mobile ? (
+    <Paper
+      elevation={2}
+      style={{
+        borderRadius: "0",
+        padding: "16px 0",
+        position: "sticky",
+        zIndex: 1,
+      }}
+    >
+      <Box sx={{ margin: "-16px 0" }}>{content}</Box>
+    </Paper>
+  ) : (
+    content
   );
 };

--- a/src/components/UI/organisms/Dashboard.tsx
+++ b/src/components/UI/organisms/Dashboard.tsx
@@ -4,6 +4,7 @@ import theme from "../../../Theme";
 import { DashboardWidgetWrapper } from "../atoms/DashboardWidgetWrapper";
 import { DashboardInfo } from "../molecules/DashboardInfo";
 import { DashboardSummary } from "../molecules/DashboardSummary";
+import { Box } from "@mui/system";
 
 interface HomeProps {
   userName?: string;
@@ -161,6 +162,7 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
         setEditDashboardMode={dashboardEditToggle}
       />
       <div className={styles.scrollableContent}>
+        <Box sx={{ height: { xs: "16px", sm: 0 } }} />
         <DashboardSummary
           summaryWidgets={summaryWidgets}
           editSummaryWidgets={setSummaryWidgets}


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-436

This pull request adds elevation and shadow to the dashboard header on mobile. The scrollable content now appears to move under the header instead of being mysteriously clipped.

![Screen Shot 2022-04-02 at 15 27 24](https://user-images.githubusercontent.com/20851553/161401844-42c69c24-bb06-42be-8646-8b11445587d5.png)

