### PR TITLE
SAF-437: Add gases map widget to dashboard

### DIFF
--- a/src/components/UI/atoms/DashboardWidgetTile.tsx
+++ b/src/components/UI/atoms/DashboardWidgetTile.tsx
@@ -8,6 +8,7 @@ import { HazardMap } from "../molecules/HazardMap";
 import { IncidentsBarGraph } from "../molecules/IncidentsBarGraph";
 import { IncidentsMap } from "../molecules/IncidentsMap";
 import { TravelMap } from "../molecules/TravelMap";
+import { GasesMap } from "./GasesMap";
 
 interface DashboardSummaryTileProps {
   widget?: any;
@@ -20,6 +21,7 @@ interface WidgetTable {
   IncidentsBarGraph: any;
   IncidentsMap: any;
   TravelMap: any;
+  GasesMap: any;
 }
 
 const useStyles = makeStyles({
@@ -88,6 +90,7 @@ export const DashboardWidgetTile: React.FC<DashboardSummaryTileProps> = (
       />
     ),
     IncidentsBarGraph: <IncidentsBarGraph filter={defaultFilter()} />,
+    GasesMap: <GasesMap filter={defaultFilter()} />,
     IncidentsMap: (
       <IncidentsMap
         filter={defaultFilter()}

--- a/src/components/UI/atoms/DashboardWidgetWrapper.tsx
+++ b/src/components/UI/atoms/DashboardWidgetWrapper.tsx
@@ -35,17 +35,11 @@ const useStyles = makeStyles<Theme, StyleProps>({
     height: (props) => {
       let containerHeight = CONTAINER_PADDING;
       if (!props.mediumScreen) {
-        if (props.numberOfWidgets > 2) {
-          containerHeight += 2 * WIDGET_HEIGHT;
-        } else {
-          containerHeight += WIDGET_HEIGHT;
-        }
+        const rows = Math.max(1, Math.ceil(props.numberOfWidgets / 2));
+        containerHeight += rows * WIDGET_HEIGHT;
       } else {
-        if (props.numberOfWidgets > 0) {
-          containerHeight += props.numberOfWidgets * WIDGET_HEIGHT;
-        } else {
-          containerHeight += WIDGET_HEIGHT;
-        }
+        const rows = Math.max(1, props.numberOfWidgets);
+        containerHeight += rows * WIDGET_HEIGHT;
       }
       return containerHeight.toString() + "px";
     },

--- a/src/components/UI/organisms/Dashboard.tsx
+++ b/src/components/UI/organisms/Dashboard.tsx
@@ -55,6 +55,10 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
       widgetName: "Incidents Bar Graph",
       widget: "IncidentsBarGraph",
     },
+    {
+      widgetName: "Gases Map",
+      widget: "GasesMap",
+    },
   ]);
 
   // Is there a way to just leave this state as empty?
@@ -105,6 +109,10 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
         {
           widgetName: "Incidents Bar Graph",
           widget: "IncidentsBarGraph",
+        },
+        {
+          widgetName: "Gases Map",
+          widget: "GasesMap",
         },
       ]);
       setActiveWidgets([


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-437

This pull request:

- Adds a gases map widget to the dashboard.

![Screen Shot 2022-04-02 at 16 08 18](https://user-images.githubusercontent.com/20851553/161402942-49c2aa92-0a70-407e-b136-12451b1fcbe2.png)

