### PR TITLE
SAF-439: Add not found page

### DIFF
--- a/src/components/Pages.tsx
+++ b/src/components/Pages.tsx
@@ -13,6 +13,7 @@ import { Incidents } from "./UI/organisms/Incidents";
 import { Locations } from "./UI/organisms/Locations";
 import { Login } from "./UI/organisms/Login";
 import { Profile } from "./UI/organisms/Profile";
+import { NotFound } from "./UI/organisms/NotFound";
 
 const useStyles = makeStyles({
   content: {
@@ -94,6 +95,7 @@ export const Pages: React.FC = () => {
                   title="SafetyWare | Profile"
                   component={Profile}
                 />
+                <Page title="SafetyWare | Not Found" component={NotFound} />
               </Switch>
             </div>
           </div>

--- a/src/components/UI/organisms/NotFound.tsx
+++ b/src/components/UI/organisms/NotFound.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Grid } from "@mui/material";
+import { Box } from "@mui/system";
+
+export const NotFound: React.FC = () => {
+  return (
+    <Grid
+      container
+      spacing={0}
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      sx={{
+        minHeight: {
+          xs: "calc(100vh - 60px)",
+          sm: "100vh",
+        },
+      }}
+    >
+      <Grid item>
+        <Box sx={{ padding: "16px", textAlign: "center" }}>
+          <h1>Oops, this page doesn&apos;t exist.</h1>
+          <p>Perhaps you&apos;re looking for one of the pages in the menu?</p>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};


### PR DESCRIPTION
Ticket: https://safetyware.atlassian.net/browse/SAF-439

This pull request:

-  Adds a "not found" page that displays when the user navigates to an unknown page. The page does not return an HTTP 404 status code because the router does not load until the page has already loaded.

![Screen Shot 2022-04-02 at 16 50 22](https://user-images.githubusercontent.com/20851553/161404005-e66aacdc-7662-46e4-88d9-ed5135290245.png)

