### PR TITLE
Pin dashboard date

### DIFF
--- a/src/components/UI/atoms/DashboardWidgetTile.tsx
+++ b/src/components/UI/atoms/DashboardWidgetTile.tsx
@@ -27,6 +27,7 @@ interface DashboardSummaryTileProps {
   widget?: any;
   removeWidget?: any;
   editDashboardMode?: any;
+  date: Date;
 }
 
 interface WidgetTable {
@@ -70,7 +71,7 @@ export const DashboardWidgetTile: React.FC<DashboardSummaryTileProps> = (
   const styles = useStyles();
   const mobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  const weekAgo = new Date();
+  const weekAgo = new Date(props.date);
   weekAgo.setDate(weekAgo.getDate() - 7);
 
   const filter: Filter = {

--- a/src/components/UI/atoms/DashboardWidgetWrapper.tsx
+++ b/src/components/UI/atoms/DashboardWidgetWrapper.tsx
@@ -17,6 +17,7 @@ interface DashboardWidgetWrapperProps {
   removeWidget?: any;
   editDashboardMode?: any;
   saveState: any;
+  date: Date;
 }
 
 export interface StyleProps {
@@ -118,6 +119,7 @@ export const DashboardWidgetWrapper: React.FC<DashboardWidgetWrapperProps> = (
                   widget={widget}
                   removeWidget={props.removeWidget}
                   editDashboardMode={props.editDashboardMode}
+                  date={props.date}
                 />
               </GridItem>
             ))}

--- a/src/components/UI/atoms/HomeGreeting.tsx
+++ b/src/components/UI/atoms/HomeGreeting.tsx
@@ -23,6 +23,7 @@ interface HomeGreetingProps {
   userName?: string;
   editDashboardMode?: any;
   setEditDashboardMode?: any;
+  date: Date;
 }
 
 const BootstrapButton = styled(Button)({
@@ -116,8 +117,7 @@ export const HomeGreeting: React.FC<HomeGreetingProps> = (props) => {
   const styles = useStyles();
   const [open, setOpen] = React.useState(false);
 
-  const date = new Date();
-  const hours = date.getHours();
+  const hours = props.date.getHours();
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -144,7 +144,7 @@ export const HomeGreeting: React.FC<HomeGreetingProps> = (props) => {
         )}
         <p className={styles.date}>
           Here is your update for{" "}
-          {date.toLocaleDateString(undefined, {
+          {props.date.toLocaleDateString(undefined, {
             weekday: "long",
             year: "numeric",
             month: "long",

--- a/src/components/UI/molecules/DashboardInfo.tsx
+++ b/src/components/UI/molecules/DashboardInfo.tsx
@@ -14,6 +14,7 @@ interface DashboardInfoProps {
   userName?: string;
   editDashboardMode?: any;
   setEditDashboardMode?: any;
+  date: Date;
 }
 
 const useStyles = makeStyles({
@@ -47,6 +48,7 @@ export const DashboardInfo: React.FC<DashboardInfoProps> = (props) => {
         userName={props.userName?.substring(0, props.userName.indexOf(" "))}
         editDashboardMode={props.editDashboardMode}
         setEditDashboardMode={props.setEditDashboardMode}
+        date={props.date}
       />
     </div>
   );

--- a/src/components/UI/molecules/DashboardSummary.tsx
+++ b/src/components/UI/molecules/DashboardSummary.tsx
@@ -22,6 +22,7 @@ interface DashboardSummaryTileProps {
   editSummaryWidgets: any;
   editDashboardMode: boolean;
   saveState: any;
+  date: Date;
 }
 
 interface numberTable {
@@ -51,18 +52,19 @@ const useStyles = makeStyles({
   },
 });
 
-const filter: Filter = {
-  // 2 days ago since no 24 hour data
-  minTimestamp: new Date(Date.now() - 2 * 86400000),
-  maxTimestamp: new Date(),
-};
-
 export const DashboardSummary: React.FC<DashboardSummaryTileProps> = (
   props
 ) => {
   const mediumScreen = useMediaQuery(theme.breakpoints.down("md"));
   const styles = useStyles();
   const user = getCurrentUser();
+
+  const weekAgo = new Date(props.date);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+
+  const filter: Filter = {
+    minTimestamp: weekAgo,
+  };
 
   const locationData = useCompanyLocations({
     companyId: user?.company.id || "",

--- a/src/components/UI/organisms/Dashboard.tsx
+++ b/src/components/UI/organisms/Dashboard.tsx
@@ -23,6 +23,11 @@ const useStyles = makeStyles({
 export const Dashboard: React.FC<HomeProps> = (props) => {
   const styles = useStyles();
 
+  // Date is pinned to the date of the capstone fair so visitors see what the judges saw.
+  // The time of day is dynamic.
+  const date = new Date();
+  date.setFullYear(2022, 3, 5);
+
   const [editDashboardMode, setEditDashboardMode] = useState(false);
 
   // Is there a way to just leave this state as empty?
@@ -168,6 +173,7 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
         userName={props.userName}
         editDashboardMode={editDashboardMode}
         setEditDashboardMode={dashboardEditToggle}
+        date={date}
       />
       <div className={styles.scrollableContent}>
         <Box sx={{ height: { xs: "16px", sm: 0 } }} />
@@ -176,6 +182,7 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
           editSummaryWidgets={setSummaryWidgets}
           editDashboardMode={editDashboardMode}
           saveState={saveState}
+          date={date}
         />
         <DashboardWidgetWrapper
           widgetState={activeWidgets}
@@ -183,6 +190,7 @@ export const Dashboard: React.FC<HomeProps> = (props) => {
           removeWidget={removeWidget}
           editDashboardMode={editDashboardMode}
           saveState={saveState}
+          date={date}
         />
       </div>
     </>


### PR DESCRIPTION
This pull request:

- Pins the dashboard date to 2022-04-05 so visitors see the same as the judges saw at the capstone fair.
- Makes all dashboard components refer to the same date object internally.

Sadly the same calculation of one week ago is repeated in two places. I did not change the structure since the project is complete.
